### PR TITLE
[PR] 1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!--next-version-placeholder-->
 
+## v1.0.2 (2022/08/28)
+
+- Verified the examples.
+- Implemented a bugfix for EXAMPLE_SYNTHETIC_REPLAYPACKS, the replaypack was set to be downloaded from URL of a branch that no longer exists.
+
 ## v1.0.1 (2022/08/28)
 
 - Implemented a bugfix for EXAMPLE_SYNTHETIC_REPLAYPACKS, the replaypack was set to be downloaded from URL of a branch that no longer exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sc2_datasets"
-version = "1.0.1"
+version = "1.0.2"
 description = "Library providing PyTorch and PyTorch Lightning API for pre-processed StarCraft II dataset SC2EGSetDataset and other datasets."
 authors = ["Andrzej Białecki", "Andrzej Szczap"]
 license = "GNU General Public License v3.0"

--- a/src/sc2_datasets/available_replaypacks.py
+++ b/src/sc2_datasets/available_replaypacks.py
@@ -5,7 +5,7 @@
 EXAMPLE_SYNTHETIC_REPLAYPACKS = [
     (
         "2022_TestReplaypack",
-        "https://github.com/Kaszanas/SC2EGSet_Dataset/raw/working_on_docs/tests/test_files/2022_TestReplaypack.zip",  # noqa
+        "https://github.com/Kaszanas/SC2EGSet_Dataset/raw/main/tests/test_files/2022_TestReplaypack.zip",  # noqa
     )
 ]
 


### PR DESCRIPTION
- Verified the examples.
- Implemented a bugfix for EXAMPLE_SYNTHETIC_REPLAYPACKS, the replaypack was set to be downloaded from URL of a branch that no longer exists.