### PR TITLE
[PR] Event sanitization, mutating loaded data with empty lists

### DIFF
--- a/src/sc2_datasets/replay_data/sc2_replay_data.py
+++ b/src/sc2_datasets/replay_data/sc2_replay_data.py
@@ -65,6 +65,9 @@ class SC2ReplayData:
         logging.info(f"Attempting to parse: {str(replay_path)}")
         with replay_path.open(mode="r", encoding="utf-8") as replay_file:
             loaded_data = json.load(replay_file)
+
+            SC2ReplayData.sanitize_events(loaded_data=loaded_data)
+
             return SC2ReplayData(
                 filepath=replay_path,
                 header=Header.from_dict(d=loaded_data["header"]),
@@ -93,6 +96,20 @@ class SC2ReplayData:
                 messageEventsErr=loaded_data.get("messageEventsErr", False),
                 trackerEventsErr=loaded_data.get("trackerEvtsErr", False),
             )
+
+    @staticmethod
+    def sanitize_events(loaded_data: dict):
+        message_events = loaded_data.get("messageEvents", [])
+        if message_events is None:
+            loaded_data["messageEvents"] = []
+
+        game_events = loaded_data.get("gameEvents", [])
+        if game_events is None:
+            loaded_data["gameEvents"] = []
+
+        tracker_events = loaded_data.get("trackerEvents", [])
+        if tracker_events is None:
+            loaded_data["trackerEvents"] = []
 
     def __hash__(self) -> int:
         """


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Added a sanitization function that mutates loaded data if any of the events lists is `None`

This is because the original JSON files can contain "null" value under the key, this will be loaded as `None` by the JSON parser. In the end, this causes issues where the dictionary lookup returns a None value, but it is not iterable in case of event lists.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#61 

